### PR TITLE
feat: モックサーバ切替用の changeToMock() を追加 (1.5.0)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "app.titech"
             artifactId = "science-tokyo-portal"
-            version = "1.4.0"
+            version = "1.5.0"
 
             from(components["java"])
 

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/ScienceTokyoPortal.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/ScienceTokyoPortal.kt
@@ -14,6 +14,15 @@ class ScienceTokyoPortal(
 ) {
     companion object {
         const val DEFAULT_USER_AGENT = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1"
+
+        /**
+         * 接続先をモックサーバ (https://extic-mock.isct.app) に切り替える。
+         * 開発時のテストアカウントによるログイン経路用。
+         * 一度呼ぶとプロセス終了まで mock URL に向き続ける。
+         */
+        fun changeToMock() {
+            BaseURL.changeToMock()
+        }
     }
     
     private val httpClient: HTTPClient = HTTPClientImpl(userAgent)

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/http/HTTPRequest.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/http/HTTPRequest.kt
@@ -3,8 +3,13 @@ package app.titech.sciencetokyoportalkit.http
 import kotlinx.serialization.json.JsonObject
 
 object BaseURL {
-    const val origin = "https://isct.ex-tic.com"
-    const val host = "isct.ex-tic.com"
+    var origin = "https://isct.ex-tic.com"
+    var host = "isct.ex-tic.com"
+
+    fun changeToMock() {
+        origin = "https://extic-mock.isct.app"
+        host = "extic-mock.isct.app"
+    }
 }
 
 object LMSBaseURL {


### PR DESCRIPTION
## Summary
- Extic SSO の base URL を \`https://extic-mock.isct.app\` に切り替える \`ScienceTokyoPortal.changeToMock()\` を追加
- 既存の [titech-portal-core-kotlin](https://github.com/TitechAppProject/titech-portal-core-kotlin) の \`TitechPortal.changeToMock()\` と同じパターン (\`object BaseURL\` の \`var\` を mock URL に書き換える companion object 関数)
- 開発時のテストアカウントで ScienceTokyo SSO のログイン経路を通せるようにするため
- LMSBaseURL は今回触らない (LMS 側 mock は別で運用済み)
- バージョンを 1.5.0 に bump (Maven Central publish 用)

## Context
[science-tokyo-portal-kit (Swift)](https://github.com/TitechAppProject/science-tokyo-portal-kit/pull/12) で先に同等の API を 1.4.0 として追加済み。
本 PR をマージすると Maven Central に 1.5.0 として publish される (deploy.yml が main push で発火)。
そのあと titechapp Android 側で \`app.titech:science-tokyo-portal:1.5.0\` に上げて \`changeToMock()\` を呼ぶ。

## Test plan
- [ ] CI の Kotlin CI (\`./gradlew test\`) が通ることを確認
- [ ] マージ後 \`Deploy to Central Publisher Portal\` workflow が成功し 1.5.0 が公開されること
- [ ] android 側で 1.5.0 を取得して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)