### PR TITLE
feat: LMSBaseURL も changeToMock() の対象にする (1.6.0)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "app.titech"
             artifactId = "science-tokyo-portal"
-            version = "1.5.0"
+            version = "1.6.0"
 
             from(components["java"])
 

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/ScienceTokyoPortal.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/ScienceTokyoPortal.kt
@@ -18,10 +18,12 @@ class ScienceTokyoPortal(
         /**
          * 接続先をモックサーバ (https://extic-mock.isct.app) に切り替える。
          * 開発時のテストアカウントによるログイン経路用。
+         * Extic SSO と LMS 双方を mock に向ける。
          * 一度呼ぶとプロセス終了まで mock URL に向き続ける。
          */
         fun changeToMock() {
             BaseURL.changeToMock()
+            LMSBaseURL.changeToMock()
         }
     }
     

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/http/HTTPRequest.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/http/HTTPRequest.kt
@@ -13,8 +13,13 @@ object BaseURL {
 }
 
 object LMSBaseURL {
-    const val origin = "https://lms.s.isct.ac.jp/2025/"
-    const val host = "lms.s.isct.ac.jp"
+    var origin = "https://lms.s.isct.ac.jp/2025/"
+    var host = "lms.s.isct.ac.jp"
+
+    fun changeToMock() {
+        origin = "https://extic-mock.isct.app/2025/"
+        host = "extic-mock.isct.app"
+    }
 }
 
 enum class HTTPMethod(val value: String) {


### PR DESCRIPTION
## Summary

- \`ScienceTokyoPortal.changeToMock()\` を呼んでも \`LMSBaseURL\` が \`const val\` でハードコードされていたため、\`getLMSDashboard()\` / \`getLMSToken()\` が本番 LMS (\`lms.s.isct.ac.jp\`) に飛んでいた。
- \`LMSBaseURL\` も \`BaseURL\` と同じ規約で \`var\` + \`changeToMock()\` に変更し、\`ScienceTokyoPortal.changeToMock()\` から両方切り替えるようにした。
- バージョンを 1.6.0 に bump。

## Test plan

- [ ] CI

## 関連

- titechapp 側 (extic-mock) 改修: 本 PR と並行で extic-mock に LMS 3 endpoints を追加する PR を別途出す
- 1.6.0 として publish する予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)