### PR TITLE
fix: gzip レスポンスを解凍できずログインに失敗する問題を修正

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = "app.titech"
             artifactId = "science-tokyo-portal"
-            version = "1.7.0"
+            version = "1.7.1"
 
             from(components["java"])
 

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/http/HTTPClient.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/http/HTTPClient.kt
@@ -3,12 +3,14 @@ package app.titech.sciencetokyoportalkit.http
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.BufferedReader
+import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.PrintStream
 import java.net.HttpCookie
 import java.net.HttpURLConnection
 import java.net.URL
 import java.net.URLEncoder
+import java.util.zip.GZIPInputStream
 import kotlin.collections.flatMap
 
 interface HTTPClient {
@@ -91,7 +93,7 @@ class HTTPClientImpl(
         } while (needRedirect)
 
         try {
-            val br = BufferedReader(InputStreamReader(connection.inputStream))
+            val br = BufferedReader(InputStreamReader(decodedStream(connection)))
 
             val sb = StringBuilder()
 
@@ -100,8 +102,6 @@ class HTTPClientImpl(
             }
 
             br.close()
-
-            connection.inputStream.close()
 
             HTTPResponse(
                 sb.toString(),
@@ -123,6 +123,17 @@ class HTTPClientImpl(
 
     override fun cookies(): List<HttpCookie> = cookies.toList()
 
+    /// Accept-Encodingを明示的に指定しているため、gzipの透過的な解凍は行われない。
+    /// Content-Encodingを見て自前で解凍する。
+    private fun decodedStream(connection: HttpURLConnection): InputStream {
+        val stream = connection.inputStream
+
+        return if (connection.contentEncoding?.equals("gzip", ignoreCase = true) == true) {
+            GZIPInputStream(stream)
+        } else {
+            stream
+        }
+    }
 
     private fun generateUrlConnection(
         url: URL,

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/AuthorizationMethodSelectionPageRequest.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/AuthorizationMethodSelectionPageRequest.kt
@@ -12,7 +12,7 @@ class AuthorizationMethodSelectionPageRequest : HTTPRequest {
         "Host" to BaseURL.host,
         "Connection" to "keep-alive",
         "Accept" to "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Encoding" to "br, gzip, deflate",
+        "Accept-Encoding" to "gzip",
         "Accept-Language" to "ja",
         "Sec-Fetch-Dest" to "document",
         "Sec-Fetch-Mode" to "navigate",

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/LMSPageRequest.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/LMSPageRequest.kt
@@ -10,7 +10,7 @@ class LMSPageRequest : HTTPRequest {
     override val headerFields = mapOf(
         "Connection" to "keep-alive",
         "Accept" to "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Encoding" to "br, gzip, deflate",
+        "Accept-Encoding" to "gzip",
         "Accept-Language" to "ja-jp"
     )
 }

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/LMSRedirectPageRequest.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/LMSRedirectPageRequest.kt
@@ -26,7 +26,7 @@ class LMSRedirectPageRequest(
             "Connection" to "keep-alive",
             "Accept" to "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
             "Content-Type" to "application/x-www-form-urlencoded; charset=UTF-8",
-            "Accept-Encoding" to "br, gzip, deflate",
+            "Accept-Encoding" to "gzip",
             "Accept-Language" to "ja",
             "Sec-Fetch-Dest" to "document",
             "Sec-Fetch-Mode" to "navigate",

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/OTPSubmitRequest.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/OTPSubmitRequest.kt
@@ -23,7 +23,7 @@ class OTPSubmitRequest(
             "Connection" to "keep-alive",
             "Content-Type" to "application/x-www-form-urlencoded; charset=UTF-8",
             "Accept" to "*/*;q=0.5, text/javascript, application/javascript, application/ecmascript, application/x-ecmascript",
-            "Accept-Encoding" to "br, gzip, deflate",
+            "Accept-Encoding" to "gzip",
             "Accept-Language" to "ja",
             "Sec-Fetch-Dest" to "empty",
             "Sec-Fetch-Mode" to "cors",

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/PasswordSubmitRequest.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/PasswordSubmitRequest.kt
@@ -24,7 +24,7 @@ class PasswordSubmitRequest(
             "Connection" to "keep-alive",
             "Content-Type" to "application/x-www-form-urlencoded; charset=UTF-8",
             "Accept" to "application/json, text/javascript, */*; q=0.01",
-            "Accept-Encoding" to "br, gzip, deflate",
+            "Accept-Encoding" to "gzip",
             "Accept-Language" to "ja",
             "Sec-Fetch-Dest" to "empty",
             "Sec-Fetch-Mode" to "cors",

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/ResourceListPageRequest.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/ResourceListPageRequest.kt
@@ -18,7 +18,7 @@ class ResourceListPageRequest(
         "Origin" to BaseURL.origin,
         "Connection" to "keep-alive",
         "Accept" to "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Encoding" to "br, gzip, deflate",
+        "Accept-Encoding" to "gzip",
         "Accept-Language" to "ja",
         "Sec-Fetch-Dest" to "document",
         "Sec-Fetch-Mode" to "navigate",

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/UserNamePageRequest.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/UserNamePageRequest.kt
@@ -10,7 +10,7 @@ class UserNamePageRequest : HTTPRequest {
     override val headerFields = mapOf(
         "Connection" to "keep-alive",
         "Accept" to "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Encoding" to "br, gzip, deflate",
+        "Accept-Encoding" to "gzip",
         "Accept-Language" to "ja-jp"
     )
 }

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/UserNameSubmitRequest.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/UserNameSubmitRequest.kt
@@ -28,7 +28,7 @@ class UserNameSubmitRequest(
             "Origin" to BaseURL.origin,
             "Connection" to "keep-alive",
             "Accept" to "application/json, text/javascript, */*; q=0.01",
-            "Accept-Encoding" to "br, gzip, deflate",
+            "Accept-Encoding" to "gzip",
             "Accept-Language" to "ja",
             "Sec-Fetch-Dest" to "empty",
             "Sec-Fetch-Mode" to "cors",

--- a/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/WaitingPageRequest.kt
+++ b/src/main/kotlin/app/titech/sciencetokyoportalkit/http/requests/WaitingPageRequest.kt
@@ -14,7 +14,7 @@ class WaitingPageRequest(
         "Origin" to BaseURL.origin,
         "Connection" to "keep-alive",
         "Accept" to "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Encoding" to "br, gzip, deflate",
+        "Accept-Encoding" to "gzip",
         "Accept-Language" to "ja",
         "Sec-Fetch-Dest" to "document",
         "Sec-Fetch-Mode" to "navigate",


### PR DESCRIPTION
## 問題

Android の TitechApp でテストアカウント (`00B00000`) のログインが必ず失敗していた。

```
ScienceTokyoPortalLoginError$InvalidUserNamePage
	at app.titech.sciencetokyoportalkit.ScienceTokyoPortal.login(ScienceTokyoPortal.kt:40)
```

## 原因

各リクエストが `Accept-Encoding: br, gzip, deflate` を明示指定しているのに、`HTTPClientImpl` は解凍を一切していなかった。

- Android の `HttpURLConnection` (中身は OkHttp) は **`Accept-Encoding` を自分で付けたときだけ**透過 gzip 解凍をする
- 素の JVM の `HttpURLConnection` は透過解凍自体を行わない
- brotli はどちらも解凍できない

結果、圧縮されたバイナリがそのまま HTML 文字列として Jsoup に渡り、`validate*Page` が落ちる。Cloudflare 上の `extic-mock` が brotli を返すため、テストアカウント経路が 100% 失敗していた。実サーバ (nginx) は観測した限り圧縮を返しておらず、実アカウント経路は表面化していなかった。

エミュレータでの実測:

| Accept-Encoding | Content-Encoding | body 先頭 |
|---|---|---|
| `br, gzip, deflate` | `br` | `8b fe 2f 00 64 1e dd f3 ...` |
| (未指定) | (なし) | `3c 21 44 4f 43 54 59 50 45` = `<!DOCTYPE` |

## 修正

- 自前で解凍できない brotli を advertise するのをやめ、`Accept-Encoding: gzip` に統一 (9 ファイル)
- `Content-Encoding: gzip` のときに `GZIPInputStream` で解凍する処理を `HTTPClientImpl` に追加

`br` を外すだけでは直らない (明示指定した時点で透過解凍が無効になるため gzip でも壊れる) 点が肝。

## 動作確認

パッチ版 jar を Android アプリ (titechapp) に差し込み、エミュレータでテストアカウントのログインを実行。`extic-mock` の 10 ステップ (TOTP → SAML → LMS トークン取得) が全部通り、"Succeed" まで到達することを確認した。

```
https://extic-mock.isct.app/auth/session
https://extic-mock.isct.app/auth/session/first_factor?identifier=00B00000
https://extic-mock.isct.app/auth/session
https://extic-mock.isct.app/auth/session/second_factor
https://extic-mock.isct.app/auth/session/second_factor
https://extic-mock.isct.app/auth/saml2/mock/assertions/mock
https://extic-mock.isct.app/idm/user/login/saml2/sso/user-isct
https://extic-mock.isct.app/2025/
https://extic-mock.isct.app/2025/auth/saml2/sp/saml2-acs.php/lms.isct.ac.jp
https://extic-mock.isct.app/2025/admin/tool/mobile/launch.php?...
```

ローカルでは JDK 17 が無く `./gradlew test` を回せなかったが (検証ビルドは JDK 21 + `release 17` の一時設定で実施)、CI (Kotlin CI) は green。

## 後続作業

merge すると deploy.yml が発火して 1.7.1 が Central Publisher Portal に自動 publish される。その後 titechapp の `android/app/build.gradle` の `app.titech:science-tokyo-portal` を `1.7.1` に bump する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
